### PR TITLE
replace strong cas with weak version inside loops

### DIFF
--- a/small/lf_lifo.h
+++ b/small/lf_lifo.h
@@ -84,7 +84,7 @@ lf_lifo_push(struct lf_lifo *head, void *elem)
 		 * coerce to unsigned short
 		 */
 		void *newhead = (char *) elem + aba_value((char *) tail + 1);
-		if (pm_atomic_compare_exchange_strong(&head->next, &tail, newhead))
+		if (pm_atomic_compare_exchange_weak(&head->next, &tail, newhead))
 			return head;
 	} while (true);
 }
@@ -106,7 +106,7 @@ lf_lifo_pop(struct lf_lifo *head)
 		 */
 		void *newhead = ((char *) lf_lifo(elem->next) +
 				 aba_value(tail));
-		if (pm_atomic_compare_exchange_strong(&head->next, &tail, newhead))
+		if (pm_atomic_compare_exchange_weak(&head->next, &tail, newhead))
 			return elem;
 	} while (true);
 }

--- a/small/quota.h
+++ b/small/quota.h
@@ -116,7 +116,7 @@ quota_set(struct quota *quota, size_t new_total)
 			return  -1;
 		uint64_t new_value =
 			((uint64_t) new_total_in_units << 32) | used_in_units;
-		if (pm_atomic_compare_exchange_strong(&quota->value, &value, new_value))
+		if (pm_atomic_compare_exchange_weak(&quota->value, &value, new_value))
 			break;
 	}
 	return new_total_in_units * QUOTA_UNIT_SIZE;
@@ -149,7 +149,7 @@ quota_use(struct quota *quota, size_t size)
 		uint64_t new_value =
 			((uint64_t) total_in_units << 32) | new_used_in_units;
 
-		if (pm_atomic_compare_exchange_strong(&quota->value, &value, new_value))
+		if (pm_atomic_compare_exchange_weak(&quota->value, &value, new_value))
 			break;
 	}
 	return size_in_units * QUOTA_UNIT_SIZE;
@@ -174,7 +174,7 @@ quota_release(struct quota *quota, size_t size)
 		uint64_t new_value =
 			((uint64_t) total_in_units << 32) | new_used_in_units;
 
-		if (pm_atomic_compare_exchange_strong(&quota->value, &value, new_value))
+		if (pm_atomic_compare_exchange_weak(&quota->value, &value, new_value))
 			break;
 	}
 	return size_in_units * QUOTA_UNIT_SIZE;


### PR DESCRIPTION
Inside loops, a spurious version of compare_exchange_* should be used
(compare_exchange_weak): on some architectures non-spurious
(compare_exchange_strong) version requires overhead in implementation,
but inside loops, spurious fail doesn't break correctness.

Closes #29