### PR TITLE
Fix Centos6 build failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
       - OS=ubuntu DIST=trusty
       - OS=ubuntu DIST=xenial
       - OS=ubuntu DIST=bionic
-      - OS=ubuntu DIST=eoan
       - OS=ubuntu DIST=focal
       - OS=debian DIST=jessie
       - OS=debian DIST=stretch

--- a/rpm/small.spec
+++ b/rpm/small.spec
@@ -7,7 +7,10 @@ License: BSD
 URL: https://github.com/tarantool/small
 Source0: https://github.com/tarantool/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
 BuildRequires: cmake >= 2.8
+%if (0%{?fedora} >= 22 || 0%{?rhel} >= 7 || 0%{?sle_version} >= 1500)
+# RHEL 6 requires devtoolset
 BuildRequires: gcc >= 4.5
+%endif
 %description
 Collection of Specialized Memory ALLocators for small allocations
 

--- a/test/mempool.c
+++ b/test/mempool.c
@@ -1,6 +1,6 @@
-#include "trivia/util.h"
 #include <small/mempool.h>
 #include <small/quota.h>
+#include <stdalign.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>


### PR DESCRIPTION
    Fix Centos6 build failed
    
    CentOS 6 is completely removed on external resources.
    We were able to build the image using the archives
    on the Vault mirror sites, but we didn't find everything
    there. We use devtoolset 7 instead,
    but devtoolset-7-gcc on CentOS 6 does not provide gcc


Closes #31