### PR TITLE
Add granularity option to small_alloc_create.

### DIFF
--- a/perf/small_alloc_perf.c
+++ b/perf/small_alloc_perf.c
@@ -211,7 +211,8 @@ small_alloc_basic(unsigned int slab_size)
 	for (unsigned int i = 0; i < SZR(slab_alloc_factor); i++) {
 		float actual_alloc_factor;
 		small_alloc_create(&alloc, &cache,
-				   OBJSIZE_MIN, slab_alloc_factor[i],
+				   OBJSIZE_MIN, sizeof(intptr_t),
+				   slab_alloc_factor[i],
 				   &actual_alloc_factor);
 		int size_min = OBJSIZE_MIN;
 		int size_max = (int)alloc.objsize_max - 1;
@@ -252,7 +253,8 @@ small_alloc_basic(unsigned int slab_size)
 	for (unsigned int i = 0; i < SZR(slab_alloc_factor); i++) {
 		float actual_alloc_factor;
 		small_alloc_create(&alloc, &cache,
-				   OBJSIZE_MIN, slab_alloc_factor[i],
+				   OBJSIZE_MIN, sizeof(intptr_t),
+				   slab_alloc_factor[i],
 				   &actual_alloc_factor);
 		int size_min = OBJSIZE_MIN;
 		int size_max = (int)alloc.objsize_max - 1;
@@ -301,7 +303,9 @@ small_alloc_large()
 	for (unsigned int i = 0; i < SZR(slab_alloc_factor); i++) {
 		float actual_alloc_factor;
 		small_alloc_create(&alloc, &cache, OBJSIZE_MIN,
-				   slab_alloc_factor[i], &actual_alloc_factor);
+				   sizeof(intptr_t),
+				   slab_alloc_factor[i],
+				   &actual_alloc_factor);
 		fail_unless(clock_gettime (CLOCK_MONOTONIC, &tm1) == 0);
 		small_alloc_test(large_size_min, large_size_max, 200, 1, 25);
 		fail_unless(clock_gettime (CLOCK_MONOTONIC, &tm2) == 0);

--- a/small/small.h
+++ b/small/small.h
@@ -162,6 +162,7 @@ struct small_alloc {
  * @param alloc - instance to create.
  * @param cache - pointer to used slab cache.
  * @param objsize_min - minimal object size.
+ * @param granularity - alignment of objects in pools
  * @param alloc_factor - desired factor of growth object size.
  * Must be in (1, 2] range.
  * @param actual_alloc_factor real allocation factor calculated the basis of
@@ -169,8 +170,8 @@ struct small_alloc {
  */
 void
 small_alloc_create(struct small_alloc *alloc, struct slab_cache *cache,
-		   uint32_t objsize_min, float alloc_factor,
-		   float *actual_alloc_factor);
+		   uint32_t objsize_min, unsigned granularity,
+		   float alloc_factor, float *actual_alloc_factor);
 
 /**
  * Enter or leave delayed mode - in delayed mode smfree_delayed()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,9 @@ target_compile_definitions(small_class_branchless.test PUBLIC SMALL_CLASS_BRANCH
 add_executable(small_alloc.test small_alloc.c)
 target_link_libraries(small_alloc.test small)
 
+add_executable(small_granularity.test small_granularity.c)
+target_link_libraries(small_granularity.test small)
+
 add_executable(lf_lifo.test lf_lifo.c)
 
 add_executable(slab_arena.test slab_arena.c)
@@ -74,6 +77,7 @@ add_test(mempool ${CMAKE_CURRENT_BUILD_DIR}/mempool.test)
 add_test(small_class ${CMAKE_CURRENT_BUILD_DIR}/small_class.test)
 add_test(small_class_branchless ${CMAKE_CURRENT_BUILD_DIR}/small_class_branchless.test)
 add_test(small_alloc ${CMAKE_CURRENT_BUILD_DIR}/small_alloc.test)
+add_test(small_granularity ${CMAKE_CURRENT_BUILD_DIR}/small_granularity.test)
 add_test(lf_lifo ${CMAKE_CURRENT_BUILD_DIR}/lf_lifo.test)
 add_test(slab_cache ${CMAKE_CURRENT_BUILD_DIR}/slab_cache.test)
 add_test(arena_mt ${CMAKE_CURRENT_BUILD_DIR}/arena_mt.test)
@@ -99,6 +103,6 @@ add_custom_target(test
     WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
     COMMAND ctest
     DEPENDS slab_cache.test region.test ibuf.test obuf.test mempool.test
-            small_alloc.test lf_lifo.test slab_arena.test arena_mt.test
-            matras.test lsregion.test quota.test rb.test
+            small_alloc.test small_granularity.test lf_lifo.test slab_arena.test
+            arena_mt.test matras.test lsregion.test quota.test rb.test
 )

--- a/test/small_alloc.c
+++ b/test/small_alloc.c
@@ -79,7 +79,9 @@ small_alloc_test(int size_min, int size_max, int objects_max,
 		 int oscillation_max, int iterations_max)
 {
 	float actual_alloc_factor;
-	small_alloc_create(&alloc, &cache, OBJSIZE_MIN, 1.3, &actual_alloc_factor);
+	small_alloc_create(&alloc, &cache, OBJSIZE_MIN,
+			   sizeof(intptr_t), 1.3,
+			   &actual_alloc_factor);
 
 	for (int i = 0; i < iterations_max; i++) {
 		small_alloc_setopt(&alloc, SMALL_DELAYED_FREE_MODE, i % 5 == 0);

--- a/test/small_granularity.c
+++ b/test/small_granularity.c
@@ -1,0 +1,147 @@
+#include <small/small.h>
+#include <small/quota.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include "unit.h"
+
+enum {
+	GRANULARITY_MIN = 4,
+	GRANULARITY_MAX = 1024,
+	ALLOCATION_COUNT = 10,
+};
+
+struct slab_arena arena;
+struct slab_cache cache;
+struct small_alloc alloc;
+struct quota quota;
+
+static unsigned *ptrs[FACTOR_POOL_MAX];
+
+static inline void
+free_checked(struct mempool *pool, unsigned *ptr)
+{
+	/*
+	 * Checking previous saved data.
+	 */
+	fail_unless(ptr[0] < FACTOR_POOL_MAX &&
+		    ptr[pool->objsize/sizeof(unsigned)-1] == ptr[0]);
+	int pos = ptr[0];
+	fail_unless(ptrs[pos] == ptr);
+	ptrs[pos][0] = ptrs[pos][pool->objsize/sizeof(unsigned)-1] = INT_MAX;
+	mempool_free(pool, ptrs[pos]);
+	ptrs[pos] = NULL;
+}
+
+static inline void *
+alloc_checked(struct mempool *pool, unsigned pos)
+{
+	fail_unless(ptrs[pos] == NULL);
+	ptrs[pos] = mempool_alloc(pool);
+	fail_unless(ptrs[pos] != NULL);
+	/*
+	 * Saving some data for test purposes
+	 */
+	ptrs[pos][0] = pos;
+	ptrs[pos][pool->objsize/sizeof(unsigned)-1] = pos;
+	return ptrs[pos];
+}
+
+static void
+small_granularity_aligment_test(void)
+{
+	header();
+	const float alloc_factor = 1.3;
+	for(unsigned int granularity = GRANULARITY_MIN;
+	    granularity <= GRANULARITY_MAX;
+	    granularity <<= 1) {
+		float actual_alloc_factor;
+		/*
+		 * Creates small_alloc with different granularity,
+		 * which must be power of two.
+		 */
+		small_alloc_create(&alloc, &cache, granularity,
+			   granularity, alloc_factor, &actual_alloc_factor);
+		/*
+		 * Checks aligment of all mempools in small alloc.
+		 */
+		for (unsigned int mempool = 0;
+		     mempool < alloc.factor_pool_cache_size;
+		     mempool++) {
+			/*
+			 * Allocates memory in each of mempools for
+			 * several objects. Each object must have at
+			 * least granularity alignment
+			 */
+			struct mempool *pool =
+				&alloc.factor_pool_cache[mempool].pool;
+			for (unsigned cnt = 0; cnt < ALLOCATION_COUNT; cnt++) {
+				ptrs[cnt] = mempool_alloc(pool);
+				uintptr_t addr = (uintptr_t)ptrs[cnt];
+				fail_unless ((addr % granularity) == 0);
+			}
+			/*
+			 * Frees previous allocated objects.
+			 */
+			for (unsigned cnt = 0; cnt < ALLOCATION_COUNT; cnt++) {
+				mempool_free(pool, ptrs[cnt]);
+				ptrs[cnt] = NULL;
+			}
+		}
+		small_alloc_destroy(&alloc);
+	}
+	footer();
+}
+
+static void
+small_granularity_allocation_test(void)
+{
+	header();
+	const float alloc_factor = 1.3;
+	for(unsigned int granularity = GRANULARITY_MIN;
+	    granularity <= GRANULARITY_MAX;
+	    granularity <<= 1) {
+		float actual_alloc_factor;
+		/*
+		 * Creates small_alloc with different granularity,
+		 * which must be power of two.
+		 */
+		small_alloc_create(&alloc, &cache, granularity,
+			   granularity, alloc_factor, &actual_alloc_factor);
+		/*
+		 * Checks allocation of all mempools in small_alloc
+		 */
+		for (unsigned int mempool = 0;
+		     mempool < alloc.factor_pool_cache_size;
+		     mempool++) {
+			struct mempool *pool =
+				&alloc.factor_pool_cache[mempool].pool;
+			ptrs[mempool] = alloc_checked(pool, mempool);
+		}
+		for (unsigned int mempool = 0;
+		     mempool < alloc.factor_pool_cache_size;
+		     mempool++) {
+			struct mempool *pool =
+				&alloc.factor_pool_cache[mempool].pool;
+			free_checked(pool, ptrs[mempool]);
+			fail_unless(mempool_used(pool) == 0);
+		}
+		small_alloc_destroy(&alloc);
+	}
+	footer();
+}
+
+int main()
+{
+	quota_init(&quota, UINT_MAX);
+
+	slab_arena_create(&arena, &quota, 0, 4000000,
+			  MAP_PRIVATE);
+	slab_cache_create(&cache, &arena);
+
+	small_granularity_aligment_test();
+	small_granularity_allocation_test();
+
+	slab_cache_destroy(&cache);
+	slab_arena_destroy(&arena);
+}

--- a/test/small_granularity.result
+++ b/test/small_granularity.result
@@ -1,0 +1,4 @@
+	*** small_granularity_aligment_test ***
+	*** small_granularity_aligment_test: done ***
+	*** small_granularity_allocation_test ***
+	*** small_granularity_allocation_test: done ***


### PR DESCRIPTION
Granularity is an option that allows user to set
multiplicity of memory allocation in small allocator.
Granulatiry must be power of two and >= sizeof(intptr_t)
in case when we used small allocator for all allocation
types and >= 4 in case when we used it for packed structs,
or types which size <= 4.