### PR TITLE
Mechanik20051988/gh 5345 fix small obuf test

### DIFF
--- a/test/obuf.c
+++ b/test/obuf.c
@@ -9,21 +9,15 @@
 enum {
 	OBJSIZE_MIN = sizeof(int),
 	OBJSIZE_MAX = 5000,
-	OBJECTS_MAX = 1000,
 	OSCILLATION_MAX = 1024,
 	ITERATIONS_MAX = 5000,
 };
 
-/** Keep global to easily inspect the core. */
-long seed;
-
 void
 alloc_checked(struct obuf *buf)
 {
-	int size = rand() % OBJSIZE_MAX;
-	if (size < OBJSIZE_MIN || size > OBJSIZE_MAX)
-		size = OBJSIZE_MIN;
-
+	int size = OBJSIZE_MIN + rand() % (OBJSIZE_MAX - OBJSIZE_MIN + 1);
+	fail_unless(size >= OBJSIZE_MIN && size <= OBJSIZE_MAX);
 	obuf_alloc(buf, size);
 }
 
@@ -62,9 +56,7 @@ int main()
 	struct slab_arena arena;
 	struct quota quota;
 
-	seed = time(0);
-
-	srand(seed);
+	srand(time(NULL));
 
 	quota_init(&quota, UINT_MAX);
 
@@ -75,5 +67,6 @@ int main()
 	obuf_basic(&cache);
 
 	slab_cache_destroy(&cache);
+	slab_arena_destroy(&arena);
 }
 

--- a/test/obuf.c
+++ b/test/obuf.c
@@ -30,10 +30,7 @@ alloc_checked(struct obuf *buf)
 static void
 basic_alloc_streak(struct obuf *buf)
 {
-	int oscillation = rand() % OSCILLATION_MAX;
-	int i;
-
-	for (i = 0; i < oscillation; ++i)
+	for (int i = 0; i < OSCILLATION_MAX; ++i)
 		alloc_checked(buf);
 }
 


### PR DESCRIPTION
There was error in test: in case when rand() % OSCILLATION_MAX return 0,
no memory allocation is made, so fail_unless(obuf_capacity(&buf) > 0)
check failed. A small refactoring was also done: add slab_arena_destroy
for graceful resources release, removed global seed value.