### PR TITLE
small: remove delayed free mode from small

### DIFF
--- a/perf/small_alloc_perf.c
+++ b/perf/small_alloc_perf.c
@@ -80,10 +80,12 @@ alloc_checked(int pos, int size_min, int size_max, int rnd, double pow_factor)
 }
 
 static int
-small_is_unused_cb(const struct mempool_stats *stats, void *arg)
+small_is_unused_cb(const void *stats, void *arg)
 {
+	const struct mempool_stats *mempool_stats =
+		(const struct mempool_stats *)stats;
 	unsigned long *slab_total = arg;
-	*slab_total += stats->slabsize * stats->slabcount;
+	*slab_total += mempool_stats->slabsize * mempool_stats->slabcount;
 	return 0;
 }
 

--- a/small/mempool.c
+++ b/small/mempool.c
@@ -159,8 +159,6 @@ mempool_create_with_order(struct mempool *pool, struct slab_cache *cache,
 			  uint32_t objsize, uint8_t order)
 {
 	assert(order <= cache->order_max);
-	lifo_init(&pool->link);
-	lifo_init(&pool->delayed);
 	pool->cache = cache;
 	slab_list_create(&pool->slabs);
 	mslab_tree_new(&pool->hot_slabs);

--- a/small/mempool.h
+++ b/small/mempool.h
@@ -121,14 +121,6 @@ typedef rb_tree(struct mslab) mslab_tree_t;
 /** A memory pool. */
 struct mempool
 {
-	/**
-	 * A link in delayed free list of pools. Must be the first
-	 * member in the struct.
-	 * @sa smfree_delayed().
-	 */
-	struct lifo link;
-	/** List of pointers for delayed free. */
-	struct lifo delayed;
 	/** The source of empty slabs. */
 	struct slab_cache *cache;
 	/** All slabs. */

--- a/small/small.c
+++ b/small/small.c
@@ -201,7 +201,7 @@ small_alloc_destroy(struct small_alloc *alloc)
 void
 small_stats(struct small_alloc *alloc,
 	    struct small_stats *totals,
-	    mempool_stats_cb cb, void *cb_ctx)
+	    int (*cb)(const void *, void *), void *cb_ctx)
 {
 	memset(totals, 0, sizeof(*totals));
 

--- a/small/small.h
+++ b/small/small.h
@@ -197,13 +197,10 @@ small_ptr_compress(struct small_alloc *alloc, void *ptr);
 void *
 small_ptr_decompress(struct small_alloc *alloc, size_t val);
 
-typedef int (*mempool_stats_cb)(const struct mempool_stats *stats,
-				void *cb_ctx);
-
 void
 small_stats(struct small_alloc *alloc,
 	    struct small_stats *totals,
-	    mempool_stats_cb cb, void *cb_ctx);
+	    int (*cb)(const void *, void *), void *cb_ctx);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/test/small_alloc.c
+++ b/test/small_alloc.c
@@ -54,10 +54,12 @@ alloc_checked(int pos, int size_min, int size_max)
 }
 
 static int
-small_is_unused_cb(const struct mempool_stats *stats, void *arg)
+small_is_unused_cb(const void *stats, void *arg)
 {
+	const struct mempool_stats *mempool_stats =
+		(const struct mempool_stats *)stats;
 	unsigned long *slab_total = arg;
-	*slab_total += stats->slabsize * stats->slabcount;
+	*slab_total += mempool_stats->slabsize * mempool_stats->slabcount;
 	return 0;
 }
 


### PR DESCRIPTION
Delayed free mode in small allocator is only used to free up tuple
memory, during snapshot creation. This is not directly related to
the small allocator itself, so moved this code to tarantool in
memtx_engine.c, where tuples memory allocation/deallocation occurs.