### PR TITLE
small: fix assertion during slab allocation

### DIFF
--- a/include/small/slab_cache.h
+++ b/include/small/slab_cache.h
@@ -279,7 +279,6 @@ slab_cache_check(struct slab_cache *cache);
 static inline uint8_t
 slab_order(struct slab_cache *cache, size_t size)
 {
-	assert(size <= UINT32_MAX);
 	if (size <= cache->order0_size)
 		return 0;
 	if (size > cache->arena->slab_size)


### PR DESCRIPTION
When `slab_get` is called from `region_alloc` or `ibuf_alloc` first
of all we try to calculate order of appropriate slab. But there is
no check that requested size with slab meta is <= UINT32_MAX, that
leads to assertion failer in `slab_order` function. Add appropriate
check to `slab_get` function, now we return NULL for such big size.