### PR TITLE
lsregion: fix pointer arithmetics on apple clang++

### DIFF
--- a/include/small/lsregion.h
+++ b/include/small/lsregion.h
@@ -268,7 +268,7 @@ lsregion_aligned_alloc(struct lsregion *lsregion, size_t size, size_t alignment,
 		return NULL;
 	struct lslab *slab = rlist_last_entry(&lsregion->slabs.slabs,
 					      struct lslab, next_in_list);
-	size += res - unaligned;
+	size += (char *)res - (char *)unaligned;
 	lslab_use(slab, size, id);
 	lsregion->slabs.stats.used += size;
 	return res;


### PR DESCRIPTION
lsregion header had an operation trying to subtract 2 void
pointers. Apple clang++ complained it is not valid. So the patch
turns it into char pointer arithmetics.

It didn't break before probably because lsregion.h wasn't included
into any .cc file.

---
I noticed it during multithreaded applier review. It does not compile locally.