### PR TITLE
build: fix CMake warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(small C CXX)
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 include(CheckFunctionExists)
 include(CheckSymbolExists)


### PR DESCRIPTION
Update minimal version to 2.8.12 to avoid
deprecation warning.

Closes #44