### PR TITLE
small: fix compilation on macOS 12

### DIFF
--- a/small/slab_arena.c
+++ b/small/slab_arena.c
@@ -228,6 +228,7 @@ slab_arena_destroy(struct slab_arena *arena)
 	if (arena->arena)
 		munmap_checked(arena->arena, arena->prealloc);
 
+	(void)total;
 	assert(total == arena->used);
 }
 


### PR DESCRIPTION
Asserts are disabled in the Release build, that leads to:

```
$ cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-Werror
$ make

[  6%] Building C object src/lib/small/CMakeFiles/small.dir/small/slab_arena.c.o
src/lib/small/small/slab_arena.c:220:9: error: variable 'total' set but not used [-Werror,-Wunused-but-set-variable]
        size_t total = 0;
               ^
```