### PR TITLE
region: add sanity check tools tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ include_directories(third_party)
 
 set(lib_headers
     "${config_h}"
+    include/small/util.h
     include/small/small_features.h
     include/small/ibuf.h
     include/small/lf_lifo.h

--- a/include/small/util.h
+++ b/include/small/util.h
@@ -1,0 +1,46 @@
+#pragma once
+/*
+ * Copyright 2022, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef __has_builtin
+#  define __has_builtin(x) 0
+#endif
+
+/**
+ * Helpers to provide the compiler with branch prediction information.
+ */
+#if __has_builtin(__builtin_expect) || defined(__GNUC__)
+#  define small_likely(x)    __builtin_expect(!! (x),1)
+#  define small_unlikely(x)  __builtin_expect(!! (x),0)
+#else
+#  define small_likely(x)    (x)
+#  define small_unlikely(x)  (x)
+#endif

--- a/test/region.c
+++ b/test/region.c
@@ -63,6 +63,128 @@ region_test_truncate()
 	footer();
 }
 
+struct region_cb_data {
+	struct region *region;
+	size_t used;
+	size_t value;
+};
+
+static void
+region_on_alloc(struct region *region, size_t size, void *cb_arg)
+{
+	struct region_cb_data *cb_data = cb_arg;
+	cb_data->region = region;
+	cb_data->used = region_used(region);
+	cb_data->value = size;
+}
+
+static void
+region_on_truncate(struct region *region, size_t used, void *cb_arg)
+{
+	struct region_cb_data *cb_data = cb_arg;
+	cb_data->region = region;
+	cb_data->used = region_used(region);
+	cb_data->value = used;
+}
+
+void
+region_test_callbacks()
+{
+	header();
+
+	struct region region;
+	struct region_cb_data data;
+
+	region_create(&region, &cache);
+	region_set_callbacks(&region,
+			     region_on_alloc, region_on_truncate, &data);
+
+	memset(&data, 0, sizeof(data));
+	void *ptr = region_alloc(&region, 10);
+	fail_unless(ptr);
+	fail_unless(region_used(&region) == 10);
+	fail_unless(data.region == &region);
+	fail_unless(data.used == 0);
+	fail_unless(data.value == 10);
+
+	memset(&data, 0, sizeof(data));
+	ptr = region_alloc(&region, 10000000);
+	fail_unless(ptr);
+	fail_unless(region_used(&region) == 10000010);
+	fail_unless(data.region == &region);
+	fail_unless(data.used == 10);
+	fail_unless(data.value == 10000000);
+
+	memset(&data, 0, sizeof(data));
+	region_truncate(&region, 10);
+	fail_unless(region_used(&region) == 10);
+	fail_unless(data.region == &region);
+	fail_unless(data.used == 10);
+	fail_unless(data.value == 10);
+
+	memset(&data, 0, sizeof(data));
+	region_free(&region);
+	fail_unless(region_used(&region) == 0);
+	fail_unless(data.region == &region);
+	fail_unless(data.used == 0);
+	fail_unless(data.value == 0);
+
+	region_reserve(&region, 100);
+	memset(&data, 0, sizeof(data));
+	ptr = region_alloc(&region, 1);
+	fail_unless(ptr);
+	fail_unless(region_used(&region) == 1);
+	fail_unless(data.region == &region);
+	fail_unless(data.used == 0);
+	fail_unless(data.value == 1);
+
+	memset(&data, 0, sizeof(data));
+	ptr = region_aligned_alloc(&region, 32, 8);
+	fail_unless(ptr);
+	fail_unless(region_used(&region) == 40);
+	fail_unless(data.region == &region);
+	fail_unless(data.used == 1);
+	fail_unless(data.value == 32 + 7);
+
+	memset(&data, 0, sizeof(data));
+	region_free(&region);
+	fail_unless(region_used(&region) == 0);
+	fail_unless(data.region == &region);
+	fail_unless(data.used == 0);
+	fail_unless(data.value == 0);
+
+	footer();
+}
+
+void
+region_test_poison()
+{
+	header();
+
+#ifndef NDEBUG
+	struct region region;
+	region_create(&region, &cache);
+	char pattern[100];
+	memset(pattern, 'P', 100);
+
+	region_reserve(&region, 100);
+	void *ptr1 = region_alloc(&region, 10);
+	memset(ptr1, 0, 10);
+	fail_unless(ptr1 != NULL);
+	void *ptr2 = region_alloc(&region, 90);
+	memset(ptr2, 0, 90);
+	fail_unless(ptr1 != NULL);
+
+	region_truncate(&region, 10);
+	fail_unless(memcmp(ptr2, pattern, 90) == 0);
+
+	region_truncate(&region, 0);
+	fail_unless(memcmp(ptr1, pattern, 10) == 0);
+#endif
+
+	footer();
+}
+
 int main()
 {
 	quota_init(&quota, UINT_MAX);
@@ -72,6 +194,8 @@ int main()
 
 	region_basic();
 	region_test_truncate();
+	region_test_callbacks();
+	region_test_poison();
 
 	slab_cache_destroy(&cache);
 }

--- a/test/region.result
+++ b/test/region.result
@@ -2,3 +2,7 @@
 	*** region_basic: done ***
 	*** region_test_truncate ***
 	*** region_test_truncate: done ***
+	*** region_test_callbacks ***
+	*** region_test_callbacks: done ***
+	*** region_test_poison ***
+	*** region_test_poison: done ***


### PR DESCRIPTION
Callbacks are intented to be used in tracking allocation/truncation to provide backtrace info when leak is found. Poisoning is intended to find use-after-free cases.

In RegionGuard `trigger` is intended to truncate region before exiting current scope to save memory in case of more allocation in the same scope. `arm` is intended to reuse same guard after triggering.