### PR TITLE
build: eliminate unused variable warn on clang 15

### DIFF
--- a/test/lf_lifo.c
+++ b/test/lf_lifo.c
@@ -51,12 +51,10 @@ int main()
 
 	/* Test overflow of ABA counter. */
 
-	int i = 0;
 	do {
 		lf_lifo_push(&head, val1);
 		fail_unless(lf_lifo_pop(&head) == val1);
 		fail_unless(lf_lifo_pop(&head) == NULL);
-		i++;
 	} while (head.next != 0);
 
 	munmap(val1, MAP_SIZE);


### PR DESCRIPTION
```
<...>/small/test/lf_lifo.c:54:6: error: variable 'i' set but not used
    [-Werror,-Wunused-but-set-variable]
        int i = 0;
```

Part of https://github.com/tarantool/tarantool/issues/8110
Fixes #57