### PR TITLE
matras: rename `matras_stat` to `matras_stats`

### DIFF
--- a/include/small/matras.h
+++ b/include/small/matras.h
@@ -140,7 +140,7 @@ typedef void *(*matras_alloc_func)(void *ctx);
 typedef void (*matras_free_func)(void *ctx, void *ptr);
 
 /** Matras statistics. */
-struct matras_stat {
+struct matras_stats {
 	/** Total number of allocated extents. */
 	matras_id_t extent_count;
 	/** Number of extents allocated for read views. */
@@ -188,7 +188,7 @@ struct matras {
 	/* Argument passed to extent allocator */
 	void *alloc_ctx;
 	/* Matras statistics. Can't be NULL (points to dummy if unset). */
-	struct matras_stat *stat;
+	struct matras_stats *stats;
 };
 
 /*
@@ -213,30 +213,30 @@ struct matras {
  * matras API declaration
  */
 
-/** Initialize a matras_stat struct. */
+/** Initialize a matras_stats struct. */
 static inline void
-matras_stat_create(struct matras_stat *stat)
+matras_stats_create(struct matras_stats *stats)
 {
-	stat->extent_count = 0;
-	stat->read_view_extent_count = 0;
+	stats->extent_count = 0;
+	stats->read_view_extent_count = 0;
 }
 
 /**
  * Initialize an empty instance of pointer translating
  * block allocator. Does not allocate memory.
  *
- * If stat isn't NULL, it should point to an initialized
- * matras_stat struct, which will be updated by the matras
+ * If stats isn't NULL, it should point to an initialized
+ * matras_stats struct, which will be updated by the matras
  * methods.
  *
- * If stat is NULL, a dummy thread-local variable will be
+ * If stats is NULL, a dummy thread-local variable will be
  * used instead. This means that in this case the matras
  * may be used only in the thread that created it.
  */
 void
 matras_create(struct matras *m, matras_id_t extent_size, matras_id_t block_size,
 	      matras_alloc_func alloc_func, matras_free_func free_func,
-	      void *alloc_ctx, struct matras_stat *stat);
+	      void *alloc_ctx, struct matras_stats *stats);
 
 /**
  * Free all memory used by an instance of matras and

--- a/small/matras.c
+++ b/small/matras.c
@@ -13,10 +13,10 @@
 #endif
 
 /**
- * Dummy thread-local matras_stat struct used if matras_stat wasn't
+ * Dummy thread-local matras_stats struct used if matras_stats wasn't
  * passed to matras_create().
  */
-static __thread struct matras_stat dummy_stat;
+static __thread struct matras_stats dummy_stats;
 
 /*
  * Binary logarithm of value (exact if the value is a power of 2,
@@ -44,7 +44,7 @@ matras_log2(matras_id_t val)
 void
 matras_create(struct matras *m, matras_id_t extent_size, matras_id_t block_size,
 	      matras_alloc_func alloc_func, matras_free_func free_func,
-	      void *alloc_ctx, struct matras_stat *stat)
+	      void *alloc_ctx, struct matras_stats *stats)
 {
 	/*extent_size must be power of 2 */
 	assert((extent_size & (extent_size - 1)) == 0);
@@ -64,7 +64,7 @@ matras_create(struct matras *m, matras_id_t extent_size, matras_id_t block_size,
 	m->alloc_func = alloc_func;
 	m->free_func = free_func;
 	m->alloc_ctx = alloc_ctx;
-	m->stat = stat ? stat : &dummy_stat;
+	m->stats = stats ? stats : &dummy_stats;
 
 	matras_id_t log1 = matras_log2(extent_size);
 	matras_id_t log2 = matras_log2(block_size);
@@ -98,7 +98,7 @@ matras_alloc_extent(struct matras *m)
 	void *ext = m->alloc_func(m->alloc_ctx);
 	if (ext) {
 		m->extent_count++;
-		m->stat->extent_count++;
+		m->stats->extent_count++;
 	}
 	return ext;
 }
@@ -108,7 +108,7 @@ matras_free_extent(struct matras *m, void *ext)
 {
 	m->free_func(m->alloc_ctx, ext);
 	m->extent_count--;
-	m->stat->extent_count--;
+	m->stats->extent_count--;
 }
 
 static inline void *
@@ -117,7 +117,7 @@ matras_copy_read_view_extent(struct matras *m, void *ext)
 	void *new_ext = matras_alloc_extent(m);
 	if (new_ext) {
 		memcpy(new_ext, ext, m->extent_size);
-		m->stat->read_view_extent_count++;
+		m->stats->read_view_extent_count++;
 	}
 	return new_ext;
 }
@@ -126,7 +126,7 @@ static inline void
 matras_free_read_view_extent(struct matras *m, void *ext)
 {
 	matras_free_extent(m, ext);
-	m->stat->read_view_extent_count--;
+	m->stats->read_view_extent_count--;
 }
 
 /**

--- a/test/matras.cc
+++ b/test/matras.cc
@@ -286,39 +286,39 @@ matras_gh_1145_test()
 }
 
 void
-matras_stat_test()
+matras_stats_test()
 {
 	std::cout << "Testing matras statistics..." << std::endl;
 
-	struct matras_stat stat;
-	matras_stat_create(&stat);
-	check(stat.extent_count == 0, "extent_count");
-	check(stat.read_view_extent_count == 0, "read_view_extent_count");
+	struct matras_stats stats;
+	matras_stats_create(&stats);
+	check(stats.extent_count == 0, "extent_count");
+	check(stats.read_view_extent_count == 0, "read_view_extent_count");
 
 	long extents_in_use = 0;
 	struct matras matras;
-	matras_create(&matras, VER_EXTENT_SIZE, sizeof(type_t), all, dea, &extents_in_use, &stat);
-	check(stat.extent_count == 0, "extent_count");
-	check(stat.read_view_extent_count == 0, "read_view_extent_count");
+	matras_create(&matras, VER_EXTENT_SIZE, sizeof(type_t), all, dea, &extents_in_use, &stats);
+	check(stats.extent_count == 0, "extent_count");
+	check(stats.read_view_extent_count == 0, "read_view_extent_count");
 
 	matras_id_t id;
 	matras_alloc(&matras, &id);
-	check(stat.extent_count == 3, "extent_count");
-	check(stat.read_view_extent_count == 0, "read_view_extent_count");
+	check(stats.extent_count == 3, "extent_count");
+	check(stats.read_view_extent_count == 0, "read_view_extent_count");
 
 	struct matras_view view;
 	matras_create_read_view(&matras, &view);
 	matras_touch(&matras, id);
-	check(stat.extent_count == 6, "extent_count");
-	check(stat.read_view_extent_count == 3, "read_view_extent_count");
+	check(stats.extent_count == 6, "extent_count");
+	check(stats.read_view_extent_count == 3, "read_view_extent_count");
 
 	matras_destroy_read_view(&matras, &view);
-	check(stat.extent_count == 3, "extent_count");
-	check(stat.read_view_extent_count == 0, "read_view_extent_count");
+	check(stats.extent_count == 3, "extent_count");
+	check(stats.read_view_extent_count == 0, "read_view_extent_count");
 
 	matras_destroy(&matras);
-	check(stat.extent_count == 0, "extent_count");
-	check(stat.read_view_extent_count == 0, "read_view_extent_count");
+	check(stats.extent_count == 0, "extent_count");
+	check(stats.read_view_extent_count == 0, "read_view_extent_count");
 
 	std::cout << "Testing matras statistics successfully finished" << std::endl;
 }
@@ -329,5 +329,5 @@ main(int, const char **)
 	matras_alloc_test();
 	matras_vers_test();
 	matras_gh_1145_test();
-	matras_stat_test();
+	matras_stats_test();
 }


### PR DESCRIPTION
In the small library all statistics structs are named `FOO_stats`, e.g. `mempool_stats`, `small_stats`. Let's rename `matras_stat` to `matras_stats` for consistency.

Fixes commit c31879f30495 ("matras: introduce statistics").
Follow-up #60