### PR TITLE
ibuf: add ibuf_truncate method

### DIFF
--- a/include/small/ibuf.h
+++ b/include/small/ibuf.h
@@ -151,6 +151,18 @@ ibuf_alloc(struct ibuf *ibuf, size_t size)
 void
 ibuf_shrink(struct ibuf *ibuf);
 
+/**
+ * Discard data written after position. Use ibuf_used to get position.
+ * Note that you should not update read position in between. It is safe
+ * to use if buffer is reallocated in between.
+ */
+static inline void
+ibuf_truncate(struct ibuf *ibuf, size_t used)
+{
+	assert(used <= ibuf_used(ibuf));
+	ibuf->wpos = ibuf->rpos + used;
+}
+
 static inline void *
 ibuf_reserve_cb(void *ctx, size_t *size)
 {

--- a/test/ibuf.result
+++ b/test/ibuf.result
@@ -2,3 +2,5 @@
 	*** test_ibuf_basic: done ***
 	*** test_ibuf_shrink ***
 	*** test_ibuf_shrink: done ***
+	*** test_ibuf_truncate ***
+	*** test_ibuf_truncate: done ***


### PR DESCRIPTION
It is used to discard data written after the given position.

Part of https://github.com/tarantool/tarantool/issues/7939