### PR TITLE
Introduce ASAN-friendly small allocators

### DIFF
--- a/include/small/quota_lessor.h
+++ b/include/small/quota_lessor.h
@@ -96,17 +96,16 @@ quota_lessor_create(struct quota_lessor *lessor, struct quota *source)
 /**
  * Destroy the quota lessor
  * @param lessor quota_lessor
- * @pre quota_leased(lessor) == 0
  */
 static inline void
 quota_lessor_destroy(struct quota_lessor *lessor)
 {
-	assert(lessor->leased == 0);
 	if (lessor->used == 0)
 		return;
 	assert(lessor->used % QUOTA_UNIT_SIZE == 0);
 	quota_release(lessor->source, lessor->used);
 	lessor->used = 0;
+	lessor->leased = 0;
 }
 
 /**

--- a/include/small/small_asan.h
+++ b/include/small/small_asan.h
@@ -56,10 +56,15 @@ struct quota_lessor;
  * Also we check that user provides same size in smfree which was in
  * smalloc call.
  *
+ * Allocator also checks for quota usage however its not precisely the same
+ * as in the regular implementation.
+ *
  * Stats are limited in particular because this implementation does not
  * have same inner structure as regular one (does not consist of mempools).
  */
 struct small_alloc {
+	/** Quota. */
+	struct quota_lessor *quota;
 	/** Number of active (not yet freed) allocations. */
 	size_t objcount;
 	/** Total size of allocations. */

--- a/test/quota_lessor.c
+++ b/test/quota_lessor.c
@@ -95,14 +95,35 @@ test_hard_lease()
 	check_plan();
 }
 
+static void
+test_leases_on_destroy()
+{
+	plan(4);
+	header();
+
+	struct quota q;
+	quota_init(&q, QUOTA_MAX);
+	struct quota_lessor l;
+	quota_lessor_create(&l, &q);
+	ok(quota_lease(&l, 100) == 100);
+	quota_lessor_destroy(&l);
+	ok(quota_leased(&l) == 0);
+	ok(quota_available(&l) == 0);
+	ok(quota_used(&q) == 0);
+
+	footer();
+	check_plan();
+}
+
 int
 main()
 {
-	plan(2);
+	plan(3);
 	header();
 
 	test_basic();
 	test_hard_lease();
+	test_leases_on_destroy();
 
 	footer();
 	return check_plan();


### PR DESCRIPTION
These allocators use distinct malloc call for every allocation where it is possible. This allows us to do buffer overflow/underflow and use-after-free checks as well as leak checks.

Additionally we do appopriate alignment to be compatible with regular allocators on the one hand and also do not lose unaligned access checks. The details are specific for every allocator and documented there.

The allocators are turned on with ENABLE_ASAN build flag (it is also used in Tarantool to build ASAN version).

Part of https://github.com/tarantool/tarantool/issues/7327

Tarantool PR is https://github.com/tarantool/tarantool/pull/8901

Merge prerequisites:
 - Tarantool PR is ready to be merged
 - ticket reference is added to PR commits