### PR TITLE
obuf: introduce obuf_is_initialized

### DIFF
--- a/include/small/mempool.h
+++ b/include/small/mempool.h
@@ -244,6 +244,12 @@ mempool_create(struct mempool *pool, struct slab_cache *cache,
 	return mempool_create_with_order(pool, cache, objsize, order);
 }
 
+/**
+ * Return true after mempool_create and false after mempool_destroy.
+ *
+ * The result of calling before obuf_create is undefined unless buf struct
+ * is zeroed out.
+ */
 static inline bool
 mempool_is_initialized(struct mempool *pool)
 {

--- a/include/small/obuf.h
+++ b/include/small/obuf.h
@@ -106,6 +106,18 @@ struct obuf
 void
 obuf_create(struct obuf *buf, struct slab_cache *slabc, size_t start_capacity);
 
+/**
+ * Return true after obuf_create and false after obuf_destroy.
+ *
+ * The result of calling before obuf_create is undefined unless buf struct
+ * is zeroed out.
+ */
+static inline bool
+obuf_is_initialized(const struct obuf *buf)
+{
+	return buf->slabc != NULL;
+}
+
 void
 obuf_destroy(struct obuf *buf);
 

--- a/small/mempool.c
+++ b/small/mempool.c
@@ -183,6 +183,8 @@ mempool_destroy(struct mempool *pool)
 	rlist_foreach_entry_safe(slab, &pool->slabs.slabs,
 				 next_in_list, tmp)
 		slab_put_with_order(pool->cache, slab);
+	/* Safety and also makes mempool_is_initialized work. */
+	memset(pool, 0, sizeof(*pool));
 }
 
 void *

--- a/small/obuf.c
+++ b/small/obuf.c
@@ -95,9 +95,8 @@ obuf_destroy(struct obuf *buf)
 		struct slab *slab = slab_from_data(buf->iov[i].iov_base);
 		slab_put(buf->slabc, slab);
 	}
-#ifndef NDEBUG
-	obuf_create(buf, buf->slabc, buf->start_capacity);
-#endif
+	/* Safety and also makes obuf_is_initialized work. */
+	memset(buf, 0, sizeof(*buf));
 }
 
 /** Add data to the output buffer. Copies the data. */

--- a/test/mempool.c
+++ b/test/mempool.c
@@ -78,18 +78,19 @@ mempool_basic()
 {
 	int i;
 
-	plan(1);
+	plan(2);
 	header();
 
 	mempool_create(&pool, &cache, objsize);
+	ok(mempool_is_initialized(&pool));
 
 	for (i = 0; i < ITERATIONS_MAX; i++) {
 		basic_alloc_streak();
 		allocating = ! allocating;
 	}
-	ok(true);
 
 	mempool_destroy(&pool);
+	ok(!mempool_is_initialized(&pool));
 
 	footer();
 	check_plan();

--- a/test/obuf.c
+++ b/test/obuf.c
@@ -33,11 +33,12 @@ obuf_basic(struct slab_cache *slabc)
 {
 	int i;
 
-	plan(1);
+	plan(3);
 	header();
 
 	struct obuf buf;
 	obuf_create(&buf, slabc, 16320);
+	ok(obuf_is_initialized(&buf));
 
 	for (i = 0; i < ITERATIONS_MAX; i++) {
 		basic_alloc_streak(&buf);
@@ -46,6 +47,7 @@ obuf_basic(struct slab_cache *slabc)
 		fail_unless(obuf_size(&buf) == 0);
 	}
 	obuf_destroy(&buf);
+	ok(!obuf_is_initialized(&buf));
 	ok(slab_cache_used(slabc) == 0);
 	slab_cache_check(slabc);
 


### PR DESCRIPTION
We check whether connection obufs are destroyed in `iproto_connection_delete` in assertion. This check is gonna be different in ASAN obuf version. Let's introduce new API function to incapsulate implementation details. For consistency with mempool we introduce `obuf_is_initialized`.

By the way let's fix `mempool_is_initialized` to return `false` after destroying for API consistency.

Part of https://github.com/tarantool/tarantool/issues/7327
Part of https://github.com/tarantool/tarantool/issues/9149

Tarantool PR for testing in CI is https://github.com/tarantool/tarantool/pull/8901. Note that testing PR tests all commits from https://github.com/tarantool/small/pull/65 but https://github.com/tarantool/small/pull/65 is based on  the commit from this PR.