### PR TITLE
asan: add obuf ASAN implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ set(lib_headers
 # ASAN implementation has extra headers that are included from regular headers.
 if(ENABLE_ASAN)
     list(APPEND lib_headers
+         include/small/obuf_asan.h
          include/small/lsregion_asan.h
          include/small/region_asan.h
          include/small/small_asan.h)
@@ -77,16 +78,17 @@ set(lib_sources
     small/slab_arena.c
     small/matras.c
     small/ibuf.c
-    small/obuf.c
     small/static.c)
 
 if(ENABLE_ASAN)
     list(APPEND lib_sources
+         small/obuf_asan.c
          small/lsregion_asan.c
          small/region_asan.c
          small/small_asan.c)
 else()
     list(APPEND lib_sources
+         small/obuf.c
          small/lsregion.c
          small/region.c
          small/small_class.c

--- a/include/small/obuf_asan.h
+++ b/include/small/obuf_asan.h
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include <sys/uio.h>
+#include <stdbool.h>
+
+#include "slab_cache.h"
+#include "util.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* defined(__cplusplus) */
+
+enum {
+	/** Maximum number of iovec vectors in obuf. */
+	SMALL_OBUF_IOV_MAX = 128,
+	/**
+	 * Number of vectors at the beginning of iovec vector list
+	 * that are allocated with distinct malloc call. Let's refer
+	 * them as checked vectors.
+	 */
+	SMALL_OBUF_IOV_CHECKED_MAX = 96,
+	/** Alignment for the checked vectors. */
+	SMALL_OBUF_ALIGNMENT = 1,
+	/** Minimum size when reserving memory. See struct obuf comment. */
+	SMALL_OBUF_MIN_RESERVE = 128,
+};
+
+static_assert(SMALL_OBUF_IOV_MAX <= IOV_MAX,
+	      "vector size should not exceed writev(2) limit");
+
+/**
+ * ASAN friendly implementation for obuf allocator. It has same interface as
+ * regular implementation but at the beginning it uses malloc() for every
+ * allocation. More precisely for the first (in terms of obuf_iovcnt())
+ * SMALL_OBUF_IOV_CHECKED_MAX allocations. Then the memory is allocated in
+ * exponentially growing blocks which then used to provide requested
+ * allocations as in the regular implementation.
+ *
+ * This combined strategy allows to do out-of-bound access checks for first
+ * allocations on the one hand and on the other hand limit the size of iov
+ * vector list. The latter is required to avoid iov vector list reallocations
+ * which is expected by some client code.
+ *
+ * See however a bit of limitation for out-of-bound access check in description
+ * of small_asan_alloc.
+ *
+ * Allocations are completely not aligned in the beginning (that is not
+ * 2 aligned). This improves unaligned memory access check.
+ *
+ * Also at the beginning we reserve at least SMALL_OBUF_MIN_RESERVE bytes
+ * so that runtime code path with ASAN implementation is similar to regular
+ * one. The overreserve is not very large comparing to regular one to reduce
+ * memory waste.
+ */
+struct obuf {
+	/** For compatibility with existing code only. */
+	struct slab_cache *slabc;
+	/** List of iovec vectors. NULL terminated. */
+	struct iovec iov[SMALL_OBUF_IOV_MAX + 1];
+	/**
+	 * Vectors starting from SMALL_OBUF_IOV_CHECKED_MAX index are
+	 * exponentially growing with factor 2 starting from this size.
+	 * Note that size can be larger than the described if larger allocation
+	 * is requested.
+	 */
+	size_t start_capacity;
+	/** How many bytes are actually allocated for each iovec. */
+	size_t capacity[SMALL_OBUF_IOV_MAX];
+	/**
+	 * If pos == 0 and iov[0] == NULL then obuf is empty. Otherwise
+	 * pos is index of the vector in the vectors list holding last
+	 * allocation. A bit odd but follows regular implementation
+	 * semantics for compatibility.
+	 */
+	int pos;
+	/** Total size of allocations. */
+	size_t used;
+	/** Whether memory is reserved with the obuf_reserve. */
+	bool reserved;
+};
+
+void
+obuf_create(struct obuf *buf, struct slab_cache *slabc, size_t start_capacity);
+
+static inline bool
+obuf_is_initialized(const struct obuf *buf)
+{
+	return buf->slabc != NULL;
+}
+
+static inline size_t
+obuf_size(struct obuf *buf)
+{
+	return buf->used;
+}
+
+void *
+obuf_reserve(struct obuf *buf, size_t size);
+
+void *
+obuf_alloc(struct obuf *buf, size_t size);
+
+static inline struct obuf_svp
+obuf_create_svp(struct obuf *buf)
+{
+	struct obuf_svp svp;
+	svp.pos = buf->pos;
+	svp.iov_len = buf->iov[buf->pos].iov_len;
+	svp.used = buf->used;
+	return svp;
+}
+
+static inline void *
+obuf_svp_to_ptr(struct obuf *buf, struct obuf_svp *svp)
+{
+	return (char *)buf->iov[svp->pos].iov_base + svp->iov_len;
+}
+
+void
+obuf_rollback_to_svp(struct obuf *buf, struct obuf_svp *svp);
+
+void
+obuf_destroy(struct obuf *buf);
+
+void
+obuf_reset(struct obuf *buf);
+
+size_t
+obuf_dup(struct obuf *buf, const void *data, size_t size);
+
+static inline int
+obuf_iovcnt(struct obuf *buf)
+{
+	return buf->iov[buf->pos].iov_base != NULL ? buf->pos + 1 : buf->pos;
+}
+
+static inline void *
+obuf_reserve_cb(void *ctx, size_t *size)
+{
+	struct obuf *buf = (struct obuf *)ctx;
+	void *ptr = obuf_reserve(buf, *size);
+	*size = buf->capacity[buf->pos] - buf->iov[buf->pos].iov_len;
+	return ptr;
+}
+
+static inline void *
+obuf_alloc_cb(void *ctx, size_t size)
+{
+	return obuf_alloc((struct obuf *)ctx, size);
+}
+
+#if defined(__cplusplus)
+} /* extern "C" */
+#endif /* defined(__cplusplus) */

--- a/small/obuf_asan.c
+++ b/small/obuf_asan.c
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2010-2023, Tarantool AUTHORS, please see AUTHORS file.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above
+ *    copyright notice, this list of conditions and the
+ *    following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials
+ *    provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY <COPYRIGHT HOLDER> ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * <COPYRIGHT HOLDER> OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+ * BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+#include "obuf.h"
+#include "util.h"
+
+#include <string.h>
+
+void
+obuf_create(struct obuf *buf, struct slab_cache *slabc, size_t start_capacity)
+{
+	buf->slabc = slabc;
+	buf->start_capacity = start_capacity;
+	memset(buf->iov, 0, lengthof(buf->iov) * sizeof(buf->iov[0]));
+	memset(buf->capacity, 0,
+	       lengthof(buf->capacity) * sizeof(buf->capacity[0]));
+	buf->pos = 0;
+	buf->used = 0;
+	buf->reserved = false;
+}
+
+/**
+ * Pointer to unallocated space. This is free space in the last allocated
+ * buffer in buf->iov that is not allocated by user.
+ */
+static char *
+obuf_unallocated_ptr(struct obuf *buf)
+{
+	return buf->iov[buf->pos].iov_base + buf->iov[buf->pos].iov_len;
+}
+
+/** Size of unallocated space. See obuf_unallocated_ptr. */
+static size_t
+obuf_unallocated_size(const struct obuf *buf)
+{
+	return buf->capacity[buf->pos] - buf->iov[buf->pos].iov_len;
+}
+
+/** Make sure size bytes are available as continuous chunk. */
+static void
+obuf_prepare_buf(struct obuf *buf, size_t size)
+{
+	size_t used = buf->iov[buf->pos].iov_len + size;
+	if (buf->pos < SMALL_OBUF_IOV_CHECKED_MAX ||
+	    used > buf->capacity[buf->pos]) {
+		size_t capacity;
+		if (buf->pos < SMALL_OBUF_IOV_CHECKED_MAX) {
+			/* See limit explanation in the header. */
+			if (size < SMALL_OBUF_MIN_RESERVE)
+				capacity = SMALL_OBUF_MIN_RESERVE;
+			else
+				capacity = size;
+		} else {
+			capacity = buf->start_capacity;
+			capacity <<= buf->pos - SMALL_OBUF_IOV_CHECKED_MAX;
+			while (capacity < size)
+				capacity <<= 1;
+		}
+
+		/* See obuf.pos semantics in struct definition. */
+		if (buf->iov[buf->pos].iov_base != NULL)
+			buf->pos++;
+		small_asan_assert(buf->pos < SMALL_OBUF_IOV_MAX);
+
+		char *alloc = small_asan_alloc(capacity,
+					       SMALL_OBUF_ALIGNMENT, 0);
+		char *payload = small_asan_payload_from_header(alloc);
+		buf->iov[buf->pos].iov_base = payload;
+		buf->iov[buf->pos].iov_len = 0;
+		buf->capacity[buf->pos] = capacity;
+	}
+	ASAN_UNPOISON_MEMORY_REGION(obuf_unallocated_ptr(buf),
+				    obuf_unallocated_size(buf));
+}
+
+void *
+obuf_reserve(struct obuf *buf, size_t size)
+{
+	small_asan_assert(!buf->reserved);
+
+	obuf_prepare_buf(buf, size);
+	buf->reserved = true;
+	return obuf_unallocated_ptr(buf);
+}
+
+void *
+obuf_alloc(struct obuf *buf, size_t size)
+{
+	if (buf->reserved) {
+		small_asan_assert(size <= obuf_unallocated_size(buf));
+		buf->reserved = false;
+	} else {
+		obuf_prepare_buf(buf, size);
+	}
+	void *ptr = obuf_unallocated_ptr(buf);
+	buf->iov[buf->pos].iov_len += size;
+	buf->used += size;
+
+	ASAN_POISON_MEMORY_REGION(obuf_unallocated_ptr(buf),
+				  obuf_unallocated_size(buf));
+	return ptr;
+}
+
+SMALL_NO_SANITIZE_ADDRESS void
+obuf_rollback_to_svp(struct obuf *buf, struct obuf_svp *svp)
+{
+	small_asan_assert(svp->pos <= (size_t)buf->pos);
+	int pos = svp->pos;
+	/*
+	 * Usually on rollback we start freeing from the position after the
+	 * position in svp but in case of rollback to 0 we may want to
+	 * free the iov[0]. This is due to inconvinient semantics of
+	 * obuf.pos See obuf.pos semantics in struct definition.
+	 */
+	if (!(svp->pos == 0 &&
+	      svp->iov_len == 0 &&
+	      buf->iov[0].iov_base != NULL))
+		pos++;
+
+	for (int i = pos; i <= buf->pos; i++) {
+		void *ptr = buf->iov[i].iov_base;
+		small_asan_free(small_asan_header_from_payload(ptr));
+	}
+
+	size_t erase_size = buf->pos - pos + 1;
+	memset(&buf->iov[pos], 0, sizeof(buf->iov[0]) * erase_size);
+	memset(&buf->capacity[pos], 0, sizeof(buf->capacity[0]) * erase_size);
+	buf->pos = svp->pos;
+	buf->used = svp->used;
+	buf->iov[buf->pos].iov_len = svp->iov_len;
+	buf->reserved = false;
+}
+
+void
+obuf_destroy(struct obuf *buf)
+{
+	struct obuf_svp svp;
+	obuf_svp_reset(&svp);
+	obuf_rollback_to_svp(buf, &svp);
+	/* Safety and also makes mempool_is_initialized work. */
+	memset(buf, 0, sizeof(*buf));
+}
+
+void
+obuf_reset(struct obuf *buf)
+{
+	struct obuf_svp svp;
+	obuf_svp_reset(&svp);
+	obuf_rollback_to_svp(buf, &svp);
+}
+
+size_t
+obuf_dup(struct obuf *buf, const void *data, size_t size)
+{
+	void *ptr = obuf_alloc(buf, size);
+	memcpy(ptr, data, size);
+	return size;
+}

--- a/test/obuf.c
+++ b/test/obuf.c
@@ -9,8 +9,12 @@
 enum {
 	OBJSIZE_MIN = sizeof(int),
 	OBJSIZE_MAX = 5000,
+#ifdef ENABLE_ASAN
+	OSCILLATION_MAX = SMALL_OBUF_IOV_CHECKED_MAX * 3,
+#else
 	OSCILLATION_MAX = 1024,
-	ITERATIONS_MAX = 5000,
+#endif
+	ITERATIONS_MAX = 1000,
 };
 
 void
@@ -18,7 +22,16 @@ alloc_checked(struct obuf *buf)
 {
 	int size = OBJSIZE_MIN + rand() % (OBJSIZE_MAX - OBJSIZE_MIN + 1);
 	fail_unless(size >= OBJSIZE_MIN && size <= OBJSIZE_MAX);
-	obuf_alloc(buf, size);
+	void *ptr = obuf_alloc(buf, size);
+	fail_unless(ptr != NULL);
+#ifdef ENABLE_ASAN
+	fail_unless(buf->iov[buf->pos + 1].iov_base == NULL);
+	fail_unless(buf->iov[buf->pos + 1].iov_len == 0);
+	if (buf->pos < SMALL_OBUF_IOV_CHECKED_MAX) {
+		fail_unless((uintptr_t)ptr % SMALL_OBUF_ALIGNMENT == 0);
+		fail_unless((uintptr_t)ptr % (2 * SMALL_OBUF_ALIGNMENT) != 0);
+	}
+#endif
 }
 
 static void
@@ -42,7 +55,6 @@ obuf_basic(struct slab_cache *slabc)
 
 	for (i = 0; i < ITERATIONS_MAX; i++) {
 		basic_alloc_streak(&buf);
-		fail_unless(obuf_capacity(&buf) > 0);
 		obuf_reset(&buf);
 		fail_unless(obuf_size(&buf) == 0);
 	}
@@ -55,13 +67,133 @@ obuf_basic(struct slab_cache *slabc)
 	check_plan();
 }
 
+static void
+obuf_rollback_run(struct slab_cache *slabc)
+{
+	struct obuf buf;
+	obuf_create(&buf, slabc, 16384);
+	struct obuf_svp *svp = malloc(sizeof(*svp) * OSCILLATION_MAX);
+	struct iovec *iov = malloc(sizeof(*iov) * OSCILLATION_MAX);
+
+	int i;
+	for (i = 0; i < OSCILLATION_MAX; i++) {
+		iov[i] = buf.iov[buf.pos];
+		svp[i] = obuf_create_svp(&buf);
+		int size = OBJSIZE_MIN +
+			   rand() % (OBJSIZE_MAX - OBJSIZE_MIN + 1);
+		void *ptr = obuf_alloc(&buf, size);
+		fail_unless(ptr != NULL);
+	}
+	i -= 1 + rand() % 6;
+	while (i > 0) {
+		obuf_rollback_to_svp(&buf, &svp[i]);
+		fail_unless(buf.pos == (int)svp[i].pos);
+		fail_unless(buf.iov[buf.pos].iov_len == svp[i].iov_len);
+		fail_unless(buf.used == svp[i].used);
+		fail_unless(buf.iov[buf.pos].iov_base == iov[i].iov_base);
+		((char *)iov[i].iov_base)[0] = '\0';
+		((char *)iov[i].iov_base)[iov[i].iov_len - 1] = '\0';
+		for (int pos = buf.pos + 1; pos <= SMALL_OBUF_IOV_MAX; pos++) {
+			fail_unless_asan(buf.iov[pos].iov_base == NULL);
+			fail_unless_asan(buf.iov[pos].iov_len == 0);
+		}
+		i -= rand() % 7;
+	}
+	obuf_rollback_to_svp(&buf, &svp[0]);
+	fail_unless(buf.pos == 0);
+	fail_unless(buf.used == 0);
+	for (int pos = 0; pos <= SMALL_OBUF_IOV_MAX; pos++) {
+		fail_unless_asan(buf.iov[pos].iov_base == NULL);
+		fail_unless_asan(buf.iov[pos].iov_len == 0);
+	}
+
+	obuf_destroy(&buf);
+	free(svp);
+	free(iov);
+}
+
+static void
+obuf_rollback(struct slab_cache *slabc)
+{
+	plan(1);
+	header();
+
+	for (int i = 0; i < 37; i++)
+		obuf_rollback_run(slabc);
+	ok(true);
+
+	footer();
+	check_plan();
+}
+
+#ifdef ENABLE_ASAN
+
+static void
+obuf_poison(struct slab_cache *slabc)
+{
+	plan(1);
+	header();
+
+	struct obuf buf;
+	obuf_create(&buf, slabc, 16384);
+	size_t size_max = 2 * small_getpagesize();
+	for (int i = 0; i < 7777; i++) {
+		size_t size_r = 1 + rand() % size_max;
+		size_t size_a = 1 + rand() % size_r;
+		char *ptr_r = obuf_reserve(&buf, size_r);
+		fail_unless(ptr_r != NULL);
+		size_t reserved = buf.capacity[buf.pos] -
+				  buf.iov[buf.pos].iov_len;
+		ptr_r[0] = 0;
+		ptr_r[reserved - 1] = 0;
+		fail_unless(__asan_address_is_poisoned(ptr_r + reserved));
+		char *ptr_a = obuf_alloc(&buf, size_a);
+		fail_unless(ptr_r == ptr_a);
+		fail_unless(__asan_address_is_poisoned(ptr_a + size_a));
+	}
+	obuf_destroy(&buf);
+	ok(true);
+
+	footer();
+	check_plan();
+}
+
+static void
+obuf_tiny_reserve_size(struct slab_cache *slabc)
+{
+	plan(1);
+	header();
+
+	struct obuf buf;
+	obuf_create(&buf, slabc, 16384);
+	size_t size_max = SMALL_OBUF_MIN_RESERVE;
+	for (int i = 0; i < SMALL_OBUF_IOV_CHECKED_MAX; i++) {
+		size_t size = 1 + rand() % size_max;
+		void *ptr = obuf_reserve(&buf, size);
+		fail_unless(ptr != NULL);
+		memset(ptr, 0, size_max);
+		obuf_alloc(&buf, size);
+	}
+	obuf_destroy(&buf);
+	ok(true);
+
+	footer();
+	check_plan();
+}
+
+#endif /* ifdef ENABLE_ASAN */
+
 int main()
 {
 	struct slab_cache cache;
 	struct slab_arena arena;
 	struct quota quota;
 
-	plan(1);
+#ifdef ENABLE_ASAN
+	plan(4);
+#else
+	plan(2);
+#endif
 	header();
 
 	unsigned int seed = time(NULL);
@@ -75,6 +207,11 @@ int main()
 	slab_cache_create(&cache, &arena);
 
 	obuf_basic(&cache);
+	obuf_rollback(&cache);
+#ifdef ENABLE_ASAN
+	obuf_poison(&cache);
+	obuf_tiny_reserve_size(&cache);
+#endif
 
 	slab_cache_destroy(&cache);
 	slab_arena_destroy(&arena);


### PR DESCRIPTION
If ENABLE_ASAN build flag is set then obuf implementation is changed. This implementation is ASAN friendly that is it allows to do buffer overflow/underflow and use-after-free checks as well as leak checks.

Part of https://github.com/tarantool/tarantool/issues/7327

Factored out from PR https://github.com/tarantool/small/pull/65 See it for a description.

Tarantool PR for testing in CI is https://github.com/tarantool/tarantool/pull/8901. Note that testing PR tests all commits from https://github.com/tarantool/small/pull/65 but https://github.com/tarantool/small/pull/65 based on commits from this PR.