### PR TITLE
small: introduce the new method `small_alloc_info`

### DIFF
--- a/include/small/small.h
+++ b/include/small/small.h
@@ -30,7 +30,23 @@
  * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+#include <stddef.h>
+#include <stdbool.h>
 #include "small_config.h"
+
+/** Information on the memory allocation. */
+struct small_alloc_info {
+	/**
+	 * True if the object is allocated on the large slab (by malloc),
+	 * false if it is allocated on the mempool.
+	 */
+	bool is_large;
+	/**
+	 * Size of the memory block that is actually allocated for the
+	 * requested size.
+	 */
+	size_t real_size;
+};
 
 #ifdef ENABLE_ASAN
 #  include "small_asan.h"
@@ -235,6 +251,16 @@ small_alloc_check(struct small_alloc *alloc)
 {
 	return slab_cache_check(alloc->cache);
 }
+
+/**
+ * Fill `info' with the information about allocation `ptr' of size `size'.
+ * See `struct small_alloc_info' for the description of each field.
+ * Note that this function can return different `info->real_size' for the same
+ * input, depending on the current `small_mempool->used_pool'.
+ */
+void
+small_alloc_info(struct small_alloc *alloc, void *ptr, size_t size,
+		 struct small_alloc_info *info);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/include/small/small_asan.h
+++ b/include/small/small_asan.h
@@ -117,6 +117,16 @@ small_alloc_check(struct small_alloc *alloc)
 	return;
 }
 
+static inline void
+small_alloc_info(struct small_alloc *alloc, void *ptr, size_t size,
+		 struct small_alloc_info *info)
+{
+	(void)alloc;
+	(void)ptr;
+	info->is_large = true;
+	info->real_size = size;
+}
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/small/small.c
+++ b/small/small.c
@@ -470,3 +470,17 @@ small_stats(struct small_alloc *alloc,
 			break;
 	}
 }
+
+void
+small_alloc_info(struct small_alloc *alloc, void *ptr, size_t size,
+		 struct small_alloc_info *info)
+{
+	(void)ptr;
+	struct small_mempool *small_mempool = small_mempool_search(alloc, size);
+	info->is_large = small_mempool == NULL;
+	if (info->is_large)
+		info->real_size = size;
+	else
+		info->real_size = small_mempool->used_pool->pool.objsize;
+	assert(info->real_size >= size);
+}


### PR DESCRIPTION
It returns the information about how the requested size of bytes would be allocated:

* `is_large` - True if the object is allocated on the large slab (by malloc), false if it is allocated on the mempool.
* `real_size` - Size of the memory block that is actually allocated for the requested size.

Needed for tarantool/tarantool#6762

Do not merge until https://github.com/tarantool/tarantool/pull/9228 is approved!