### PR TITLE
slab: fix `NULL` ptr deref in assertion in `slab_get`

### DIFF
--- a/small/slab_cache.c
+++ b/small/slab_cache.c
@@ -322,7 +322,7 @@ slab_get(struct slab_cache *cache, size_t size)
 		slab = slab_get_large(cache, size);
 	else
 		slab = slab_get_with_order(cache, order);
-	assert(slab->size == slab_real_size(cache, size));
+	assert(slab == NULL || slab->size == slab_real_size(cache, size));
 	return slab;
 }
 


### PR DESCRIPTION
`slab_get_large` and `slab_get_with_order` may return `NULL` so we should be careful in the following assertion.

Part of tarantool/tarantool#9218