### PR TITLE
slab: fix `uint32_t` overflow in `slab_capacity`

### DIFF
--- a/include/small/slab_cache.h
+++ b/include/small/slab_cache.h
@@ -268,14 +268,14 @@ slab_cache_set_thread(struct slab_cache *cache)
 #endif /* ifndef ENABLE_ASAN */
 
 /** Aligned size of slab meta. */
-static inline uint32_t
-slab_sizeof()
+static inline size_t
+slab_sizeof(void)
 {
 	return small_align(sizeof(struct slab), sizeof(intptr_t));
 }
 
 /** Useful size of a slab. */
-static inline uint32_t
+static inline size_t
 slab_capacity(struct slab *slab)
 {
 	return slab->size - slab_sizeof();


### PR DESCRIPTION
A slab may be larger than 4 GB, see `slab_get_large`, so we should use `size_t` for its capacity, not `uint32_t`.

The `uint32_t` overflow may cause assertion failures in `ibuf` when it grows larger than 4 GB.

Part of tarantool/tarantool#9218