### PR TITLE
ibuf: introduce ibuf_consume/ibuf_consume_before API

### DIFF
--- a/small/ibuf.c
+++ b/small/ibuf.c
@@ -79,6 +79,7 @@ ibuf_reserve_slow(struct ibuf *ibuf, size_t size)
 	 * Otherwise, get a bigger buffer.
 	 */
 	if (size + used <= capacity) {
+		ibuf_unpoison_consumed(ibuf);
 		ibuf_unpoison_unallocated(ibuf);
 		memmove(ibuf->buf, ibuf->rpos, used);
 	} else {


### PR DESCRIPTION
This interface is supposed to be used to tell that we process a piece of data from the read end of the buffer and don't need it anymore.

Required for PR https://github.com/tarantool/tarantool/pull/9272