### PR TITLE
test: fix test build for Debian 9 and alike

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,7 @@ add_definitions("-D__STDC_FORMAT_MACROS=1")
 add_definitions("-D__STDC_LIMIT_MACROS=1")
 add_definitions("-D__STDC_CONSTANT_MACROS=1")
 
-add_library(small_unit OBJECT unit.c)
+add_library(small_unit STATIC unit.c)
 
 add_executable(slab_cache.test slab_cache.c)
 target_link_libraries(slab_cache.test small small_unit)


### PR DESCRIPTION
Looks like Debian 9 CMake version is old. According to CMake documentation OBJECT library can be used in target_link_libraries since 3.12

```
CMake Error at src/lib/small/test/CMakeLists.txt:9 (target_link_libraries):
  Target "small_unit" of type OBJECT_LIBRARY may not be linked into another
  target.  One may link only to STATIC or SHARED libraries, or to executables
  with the ENABLE_EXPORTS property set.
```