### PR TITLE
matras: increase max capacity from `2^31` to `2^32` blocks

### DIFF
--- a/include/small/matras.h
+++ b/include/small/matras.h
@@ -117,6 +117,7 @@
 
 #include <assert.h>
 #include <stdint.h>
+#include <stddef.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -157,7 +158,7 @@ struct matras_view {
 	/* root extent of the view */
 	void *root;
 	/* block count in the view */
-	matras_id_t block_count;
+	size_t block_count;
 	/* all views are linked into doubly linked list */
 	struct matras_view *prev_view, *next_view;
 };
@@ -176,7 +177,7 @@ struct matras {
 	/* Number of allocated extents */
 	matras_id_t extent_count;
 	/* Maximum possible number of created blocks */
-	matras_id_t capacity;
+	size_t capacity;
 	/* See "Shifts and masks explanation" below  */
 	matras_id_t shift1, shift2;
 	/* See "Shifts and masks explanation" below  */

--- a/small/matras.c
+++ b/small/matras.c
@@ -71,21 +71,17 @@ matras_create(struct matras *m, matras_id_t extent_size, matras_id_t block_size,
 	matras_id_t log3 = matras_log2(sizeof(void *));
 	matras_id_t log2_capacity = log1 * 3 - log2 - log3 * 2;
 	/*
-	 * Given extent_size = 16384 and block_size = 16, the capacity is 2^32
-	 * blocks, however this number is 1 more than can be represented by the
-	 * 32-bit matras_view::block_count. To avoid its overflow, the capacity
-	 * is intentionally limited to 2^31 blocks, which ought to be enough for
-	 * anybody.
+	 * Given 32-bit block identifiers, the maximum possible number of
+	 * provided blocks is 2^32.
 	 */
-	if (log2_capacity > 31)
-		log2_capacity = 31;
-	m->capacity = (matras_id_t)1 << log2_capacity;
+	if (log2_capacity > UINT32_WIDTH)
+		log2_capacity = UINT32_WIDTH;
+	m->capacity = (size_t)1 << log2_capacity;
 	m->shift1 = log1 * 2 - log2 - log3;
 	m->shift2 = log1 - log2;
 	m->mask1 = (((matras_id_t)1) << m->shift1) - ((matras_id_t)1);
 	m->mask2 = (((matras_id_t)1) << m->shift2) - ((matras_id_t)1);
 }
-
 
 /**
  * Free all memory used by an instance of matras and


### PR DESCRIPTION
Commit 7aff04fe0b65 ("matras: fix `matras_view::block_count` overflow") limited the capacity of a single instance of matras to 2<sup>31</sup> blocks, however this limit is too conservative. It is actually possible to address 2<sup>32</sup> blocks, just need to make `block_count` and `capacity` fields 64-bit to avoid the overflow.

Needed for tarantool/tarantool#9864