### PR TITLE
 lsregion: introduce lsregion_to_iovec method

### DIFF
--- a/include/small/lsregion_asan.h
+++ b/include/small/lsregion_asan.h
@@ -30,6 +30,7 @@
  */
 #include <stddef.h>
 #include <stdint.h>
+#include <sys/uio.h>
 
 #include "rlist.h"
 #include "slab_arena.h"
@@ -86,6 +87,10 @@ lsregion_alloc(struct lsregion *lsregion, size_t size, int64_t id)
 
 void
 lsregion_gc(struct lsregion *lsregion, int64_t min_id);
+
+int64_t
+lsregion_to_iovec(const struct lsregion *lsregion, struct iovec *iov,
+		  int *iovcnt, struct lsregion_svp *svp);
 
 static inline void
 lsregion_destroy(struct lsregion *lsregion)

--- a/include/small/rlist.h
+++ b/include/small/rlist.h
@@ -125,7 +125,7 @@ rlist_shift_tail(struct rlist *head)
  * return first element
  */
 static SMALL_ALWAYS_INLINE struct rlist *
-rlist_first(struct rlist *head)
+rlist_first(const struct rlist *head)
 {
 	return head->next;
 }
@@ -134,7 +134,7 @@ rlist_first(struct rlist *head)
  * return last element
  */
 static SMALL_ALWAYS_INLINE struct rlist *
-rlist_last(struct rlist *head)
+rlist_last(const struct rlist *head)
 {
 	return head->prev;
 }
@@ -143,7 +143,7 @@ rlist_last(struct rlist *head)
  * return next element by element
  */
 static SMALL_ALWAYS_INLINE struct rlist *
-rlist_next(struct rlist *item)
+rlist_next(const struct rlist *item)
 {
 	return item->next;
 }
@@ -152,7 +152,7 @@ rlist_next(struct rlist *item)
  * return previous element
  */
 static SMALL_ALWAYS_INLINE struct rlist *
-rlist_prev(struct rlist *item)
+rlist_prev(const struct rlist *item)
 {
 	return item->prev;
 }
@@ -161,7 +161,7 @@ rlist_prev(struct rlist *item)
  * return TRUE if list is empty
  */
 static SMALL_ALWAYS_INLINE int
-rlist_empty(struct rlist *item)
+rlist_empty(const struct rlist *item)
 {
 	return item->next == item->prev && item->next == item;
 }


### PR DESCRIPTION
lsregion is a good candidate for an output buffer, maybe even better
than obuf:

Obuf may be freed / flushed only completely, meaning you need two obufs
to be able to simultaneously flush one of them and write to the other.

At the same time, lsregion may be gradually freed up to the last flushed
position without blocking the incoming writes.

In order to use lsregion as an output buffer, introduce
lsregion_to_iovec method, which will simply enumerate all the allocated
slabs and their sizes and save their contents to the provided iovec
array.

Since the last flushed slab may still be used by further allocations
(which may happen while the flushed data is being written), introduce a
lsregion_svp helper struct, which tracks the last flushed position.

Last flushed slab is determined by flush_id - max_id used for
allocations in this slab at the moment of flush.

Compared to obuf (which stores data in a set of <= 32 progressively
growing iovecs), it's theoretically possible to overflow the IOV_MAX
(1024) by using lsregion, and thus require multiple writev calls to
flush it, but given that lsregion is usually created with runtime slab
arenam, which allocates 4 megabyte slabs to store the data, it's highly
unlikely. It would require allocating 4 gigabytes of data per one flush.

Needed for https://github.com/tarantool/tarantool/issues/10161