### PR TITLE
lsregion: implement lsregion_reserve for asan build

### DIFF
--- a/include/small/lsregion_asan.h
+++ b/include/small/lsregion_asan.h
@@ -63,8 +63,15 @@ struct lsregion_allocation {
 	struct rlist link;
 	/** Allocation size. */
 	size_t size;
+	/**
+	 * Actually used allocation size. May be less than size, if there was no
+	 * alloc() matching a reserve(), or if alloc() uses less memory.
+	 */
+	size_t used;
 	/** Allocation id. */
 	int64_t id;
+	/** Allocation alignment. */
+	size_t alignment;
 };
 
 static inline void
@@ -73,6 +80,16 @@ lsregion_create(struct lsregion *lsregion, struct slab_arena *arena)
 	(void)arena;
 	lsregion->used = 0;
 	rlist_create(&lsregion->allocations);
+}
+
+void *
+lsregion_aligned_reserve(struct lsregion *lsregion, size_t size,
+			 size_t alignment);
+
+static inline void *
+lsregion_reserve(struct lsregion *lsregion, size_t size)
+{
+	return lsregion_aligned_reserve(lsregion, size, 1);
 }
 
 void *


### PR DESCRIPTION
lsregion_reserve() was never used separately from lsregion_alloc in our code base, so a separate lsregion_reserve() implementation for asan wasn't needed.

This is going to change, so let's implement the missing method.

Also reenable basic reserve tests for asan build.

Needed for tarantool/tarantool#10161

The asan build with tarantool is tested here: https://github.com/tarantool/tarantool/pull/9922/commits/5d368091bafccd39c2a9cf246e710f3daf3395b7 (release_asan_clang and debug_asan_clang workflows)