### PR TITLE
rlist: make foreach_enrty_* macros not to use UB

### DIFF
--- a/include/small/rlist.h
+++ b/include/small/rlist.h
@@ -42,10 +42,6 @@ extern "C" {
 #define typeof __typeof__
 #endif
 
-#ifndef offsetof
-#define offsetof(type, member) ((size_t) &((type *)0)->member)
-#endif
-
 /**
  * List entry and head structure.
  *
@@ -280,8 +276,7 @@ rlist_cut_before(struct rlist *head1, struct rlist *head2, struct rlist *item)
  * return entry by list item
  */
 #define rlist_entry(item, type, member) ({				\
-	const typeof( ((type *)0)->member ) *__mptr = (item);		\
-	(type *)( (char *)__mptr - offsetof(type,member));		\
+	(type *)( (char *)(item) - offsetof(type,member));		\
 })
 
 /**

--- a/include/small/util.h
+++ b/include/small/util.h
@@ -58,6 +58,14 @@
 #  define __has_attribute(x) 0
 #endif
 
+#ifndef offsetof
+#  if __has_builtin(__builtin_offsetof)
+#    define offsetof(type, member) __builtin_offsetof(type, member)
+#  else
+#    define offsetof(type, member) ((size_t)&((type *)0)->member)
+#  endif
+#endif /* offsetof */
+
 /**
  * Add `always_inline` attribute to the function if possible. Add inline too.
  * Such function will always be inlined.

--- a/test/lsregion.c
+++ b/test/lsregion.c
@@ -4,12 +4,6 @@
 #include <string.h>
 #include "unit.h"
 
-
-/* For the sake of lsregion_alloc_object (it demands alignof()) */
-#ifndef offsetof
-#define offsetof(type, member) ((size_t) &((type *)0)->member)
-#endif
-
 #if !defined(alignof) && !defined(__alignof_is_defined)
 #  if __has_feature(c_alignof) || (defined(__GNUC__) && __GNUC__ >= 5)
 #    include <stdalign.h>


### PR DESCRIPTION
Changed default tarantool `offsetof` macro implementation so it don't
access members of null pointer in typeof. Also fixed the same problem
in `rlist_entry_is_head`.

Needed for https://github.com/tarantool/tarantool/issues/10143

NO_DOC=bugfix
NO_CHANGELOG=minor
NO_TEST=tested manually with fuzzer