### PR TITLE
test: get rid of debug message

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,6 @@ add_definitions("-D__STDC_LIMIT_MACROS=1")
 add_definitions("-D__STDC_CONSTANT_MACROS=1")
 
 function(create_test test_name test_executable)
-  message(STATUS ${test_name} ${test_executable})
   add_test(${test_name} ${test_executable})
   set_tests_properties(${test_name} PROPERTIES
     LABELS tarantool_small


### PR DESCRIPTION
Follows up commit 55061d89473e
("test: introduce a CMake function create_test").