### PR TITLE
small: fix crash with low alloc_factor and high memory pressure

### DIFF
--- a/small/small.c
+++ b/small/small.c
@@ -281,20 +281,13 @@ small_mempool_create(struct small_alloc *alloc)
 						    pool - 1);
 			cur_order_pool = pool;
 		}
-		/*
-		 * Maximum object size for mempool allocation ==
-		 * alloc->objsize_max. If we have reached this size,
-		 * there will be no more pools - loop will be broken
-		 * at the next iteration. So we need to create the last
-		 * group of pools.
-		 */
-		if (objsize == alloc->objsize_max) {
-			assert(cur_order_pool->pool.slab_ptr_mask ==
-			       pool->pool.slab_ptr_mask);
-			small_mempool_create_groups(alloc, cur_order_pool,
-						    pool);
-		}
 	}
+	int mempool_cache_size = alloc->small_mempool_cache_size;
+	struct small_mempool *last_pool =
+		&alloc->small_mempool_cache[mempool_cache_size - 1];
+	assert(cur_order_pool->pool.slab_ptr_mask ==
+	       last_pool->pool.slab_ptr_mask);
+	small_mempool_create_groups(alloc, cur_order_pool, last_pool);
 	alloc->objsize_max = objsize;
 }
 


### PR DESCRIPTION
If alloc_factor is small so that number of small mempools is SMALL_MEMPOOL_MAX we fail to call small_mempool_create_groups() for the last group of mempools.

Needed for https://github.com/tarantool/tarantool/issues/10148

Tarantool PR with bump https://github.com/tarantool/tarantool/pull/10519