### PR TITLE
slab cache: fix slab alignment to 16 bytes

### DIFF
--- a/include/small/slab_cache_asan.h
+++ b/include/small/slab_cache_asan.h
@@ -40,7 +40,7 @@ extern "C" {
 
 enum {
 	/** Alignment for slabs from ASAN slab cache. */
-	SMALL_CACHE_SLAB_ALIGNMENT = sizeof(long long),
+	SMALL_CACHE_SLAB_ALIGNMENT = 16,
 };
 
 /**

--- a/test/slab_cache.c
+++ b/test/slab_cache.c
@@ -121,12 +121,35 @@ test_slab_membership(void)
 	check_plan();
 }
 
+static void
+test_slab_alignment(void)
+{
+	plan(1);
+	header();
+
+	slab_arena_create(&arena, &quota, 0, 4000000, MAP_PRIVATE);
+	slab_cache_create(&cache, &arena);
+
+	long double *x = (long double *)slab_get(&cache, 1000);
+	*x = 1;
+	ok(true);
+	slab_put(&cache, (struct slab *)x);
+	slab_cache_destroy(&cache);
+
+	footer();
+	check_plan();
+}
+
 #endif
 
 int
 main(void)
 {
+#ifdef ENABLE_ASAN
+	plan(3);
+#else
 	plan(2);
+#endif
 	header();
 
 	unsigned int seed = time(NULL);
@@ -137,6 +160,7 @@ main(void)
 	test_slab_cache();
 #ifdef ENABLE_ASAN
 	test_slab_membership();
+	test_slab_alignment();
 #else
 	test_slab_real_size();
 #endif


### PR DESCRIPTION
It was 8 bytes by mistake. We should align slabs as malloc at least ie the pointer should be suitable to store any type.

Before the change the newly added test failed:

    # *** test_slab_alignment ***
/home/shiny/dev/tarantool/src/lib/small/test/slab_cache.c:134:2: runtime error: store to misaligned address 0x521000001528 for type 'long double', which requires 16 byte alignment 0x521000001528: note: pointer points here
 be be 20 00  00 10 00 00 00 00 00 00  be be be be be be be be  be be be be be be be be  be be be be
              ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/shiny/dev/tarantool/src/lib/small/test/slab_cache.c:134:2 in