### PR TITLE
mempool: fix UBSan errors regarding misaligned access

### DIFF
--- a/small/mempool.c
+++ b/small/mempool.c
@@ -76,8 +76,7 @@ mslab_alloc(struct mempool *pool, struct mslab *slab)
 		 * because (void **)slab->free_list has not necessary aligment.
 		 * memcpy can work with misaligned address.
 		 */
-		memcpy(&slab->free_list, (void **)slab->free_list,
-		       sizeof(void *));
+		memcpy(&slab->free_list, slab->free_list, sizeof(void *));
 	} else {
 		/* Use an object from the "untouched" area of the slab. */
 		result = (char *)slab + slab->free_offset;
@@ -106,7 +105,7 @@ mslab_free(struct mempool *pool, struct mslab *slab, void *ptr)
 	 * because ptr has not necessary aligment. memcpy can work
 	 * with misaligned address.
 	 */
-	memcpy((void **)ptr, &slab->free_list, sizeof(void *));
+	memcpy(ptr, &slab->free_list, sizeof(void *));
 	slab->free_list = ptr;
 	VALGRIND_FREELIKE_BLOCK(ptr, 0);
 	VALGRIND_MAKE_MEM_DEFINED(ptr, sizeof(void *));


### PR DESCRIPTION
The type cast is unnecessary and causes false-positive errors:

```
./small/mempool.c:109:9: runtime error: store to misaligned address 0x79651c000074 for type 'void **', which requires 8 byte alignment 0x79651c000074: note: pointer points here
  00 00 00 00 23 23 23 23  50 50 50 50 50 50 50 50  50 50 50 50 50 50 50 50  50 50 50 50 50 50 50 50
              ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ./small/mempool.c:109:9
```

Needed for tarantool/tarantool#10631