### PR TITLE
arena: do not limit preallocated size to quota

### DIFF
--- a/small/slab_arena.c
+++ b/small/slab_arena.c
@@ -190,8 +190,6 @@ slab_arena_create(struct slab_arena *arena, struct quota *quota,
 	arena->slab_size = small_round(MAX(slab_size, SLAB_MIN_SIZE));
 
 	arena->quota = quota;
-	/** Prealloc can not be greater than the quota */
-	prealloc = MIN(prealloc, quota_total(quota));
 	/** Extremely large sizes can not be aligned properly */
 	prealloc = MIN(prealloc, SIZE_MAX - arena->slab_size);
 	/* Align prealloc around a fixed number of slabs. */

--- a/test/slab_arena.c
+++ b/test/slab_arena.c
@@ -211,7 +211,7 @@ slab_test_basic(void)
 
 	quota_init(&quota, 2000000);
 	slab_arena_create(&arena, &quota, 3000000, 1, MAP_PRIVATE);
-	ok_no_asan(arena.prealloc == 2031616);
+	ok_no_asan(arena.prealloc == 3014656);
 	ok(quota_total(&quota) == 2000896);
 	ok_no_asan(arena.used == 0);
 	ok(arena.slab_size == SLAB_MIN_SIZE);


### PR DESCRIPTION
We are going to use arena in new mode. Preallocate large amount of memory beforehand and then grow quota as required. Preallocated memory is not mapped immediently anyway.

Part of tarantool/tarantool#10429