### PR TITLE
Perf test fixes

### DIFF
--- a/perf/small.cc
+++ b/perf/small.cc
@@ -251,6 +251,8 @@ small_workload_benchmark(benchmark::State& state)
 		free_object(v);
 	}
 
+	state.SetItemsProcessed(prealloc_objcount);
+
 finish:
 	free_objects(v);
 	if (! small_is_unused())

--- a/perf/small.cc
+++ b/perf/small.cc
@@ -279,7 +279,8 @@ generate_benchmark_args(benchmark::internal::Benchmark* b)
 
 BENCHMARK(small_workload_benchmark)
 	->Apply(generate_benchmark_args)
-	->ArgNames({"slab_size", "size_min", "size_max", "prealloc"});
+	->ArgNames({"slab_size", "size_min", "size_max", "prealloc", "mask",
+		    "alloc_factor_idx"});
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
Fixes the assertion failure in the performance test and provides the `items_per_second` metric to be stored in Grafana if run in the Tarantool's CI.