### PR TITLE
static: increase static buffer size to 36KiB

### DIFF
--- a/include/small/static.h
+++ b/include/small/static.h
@@ -36,11 +36,10 @@
 
 enum {
 	/**
-	 * Two pages (8192) would be too small for arbitrary
-	 * cases, but plus even 1 byte would occupy the whole new
-	 * page anyway, so here it is 3 pages.
+	 * This should be a multiple of the page size (usually 4096).
+	 * Four pages should be enough for most cases.
 	 */
-	SMALL_STATIC_SIZE = 4096 * 3,
+	SMALL_STATIC_SIZE = 4096 * 9,
 };
 
 /**


### PR DESCRIPTION
This patch increases the static cyclic allocator buffer to 36KiB (4096 * 9 bytes) from 12KiB (4096 * 3 bytes).

We need 2 buffers of size 16KiB for formating log entry in json format in tarantool logger, because of the padding we actually reserve 9 pages of 4096 bytes here.

Needed for tarantool/tarantool#10918