### PR TITLE
matras: introduce the matras_alloc_reserve function

### DIFF
--- a/include/small/matras.h
+++ b/include/small/matras.h
@@ -311,6 +311,13 @@ int
 matras_touch_reserve(struct matras *m, int count);
 
 /**
+ * Reserve the max amount of extents required to successfully allocate @p count
+ * blocks. The extents are reserved in the allocator given on construction.
+ */
+int
+matras_alloc_reserve(struct matras *m, int count);
+
+/**
  * Convert block id into block address.
  */
 static void *

--- a/include/small/util.h
+++ b/include/small/util.h
@@ -88,6 +88,8 @@
 #  define lengthof(array) (sizeof (array) / sizeof ((array)[0]))
 #endif
 
+#define SMALL_DIV_ROUND_UP(a, b) ((a) + (b) - 1) / (b)
+
 #define small_xmalloc(size)							\
 	({									\
 		void *ret = malloc(size);					\


### PR DESCRIPTION
The function is meant to be used in order to reserve the amount of extents possibly required to allocate the specified amount of blocks.

Needed for tarantool/tarantool#10831