### PR TITLE
lf_lifo: fix UB on pointer arithmetic with NULL

### DIFF
--- a/test/lf_lifo.c
+++ b/test/lf_lifo.c
@@ -30,7 +30,8 @@ mmap_aligned(size_t size)
 
 #define MAP_SIZE 0x10000
 
-int main()
+static void
+test_basic(void)
 {
 	plan(8);
 	header();
@@ -65,6 +66,33 @@ int main()
 	munmap(val1, MAP_SIZE);
 	munmap(val2, MAP_SIZE);
 	munmap(val3, MAP_SIZE);
+
+	footer();
+	check_plan();
+}
+
+static void
+test_integer_pointer_conversion(void)
+{
+	plan(1);
+	header();
+
+	for (int i = 0; i < SMALL_LIFO_ALIGNMENT; i++)
+		fail_unless((intptr_t)(void *)(uintptr_t)i == i);
+	ok(true);
+
+	footer();
+	check_plan();
+}
+
+int
+main(void)
+{
+	plan(2);
+	header();
+
+	test_integer_pointer_conversion();
+	test_basic();
 
 	footer();
 	return check_plan();


### PR DESCRIPTION
ASAN report:

```
tarantool/src/lib/small/include/small/lf_lifo.h:86:59: runtime error: applying non-zero offset 1 to null pointer
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/shiny/dev/tarantool/src/lib/small/include/small/lf_lifo.h:86:59
```

Let's explicitly handle NULL pointer case. Also add test for implementation defined behaviour on integer to pointer conversion and back. We rely on this behaviour for ABA counter for NULL pointer.

Note that currently we globally suppress some UB issues so we do not check the fix in CI yet. Manual check is done.
Before patch, without suppressions test is failed as described above and passed after patch.

Removed suppressions:
```diff
diff --git a/cmake/compiler.cmake b/cmake/compiler.cmake
index d6db669f05..e057f0dea5 100644
--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -236,18 +236,14 @@ macro(enable_tnt_compile_flags)
         string(JOIN "," UBSAN_IGNORE_OPTIONS
             # Gives compilation warnings when -O0 is used, which is always,
             # because some tests build with -O0.
-            object-size
             # See https://github.com/tarantool/tarantool/issues/10742.
-            pointer-overflow
             # NULL checking is disabled, because this is not a UB and raises
             # lots of false-positive fails such as typeof(*obj) with
             # obj == NULL, or memcpy() with NULL argument and 0 size.
             # "UBSan: check null is globally suppressed",
             # https://github.com/tarantool/tarantool/issues/10741
-            null
             # "UBSan: check nonnull-attribute is globally suppressed",
             # https://github.com/tarantool/tarantool/issues/10740
-            nonnull-attribute
         )
         # GCC has no "function" UB check. See details here:
```

Closes #104

Module bump in Tarantool PR is https://github.com/tarantool/tarantool/pull/11296.