### PR TITLE
small: improve `real_size` calculation in `small_alloc_info`

### DIFF
--- a/include/small/small.h
+++ b/include/small/small.h
@@ -225,8 +225,6 @@ small_alloc_check(struct small_alloc *alloc)
 /**
  * Fill `info' with the information about allocation `ptr' of size `size'.
  * See `struct small_alloc_info' for the description of each field.
- * Note that this function can return different `info->real_size' for the same
- * input, depending on the current `small_mempool->used_pool'.
  */
 void
 small_alloc_info(struct small_alloc *alloc, void *ptr, size_t size,

--- a/small/small.c
+++ b/small/small.c
@@ -468,12 +468,14 @@ void
 small_alloc_info(struct small_alloc *alloc, void *ptr, size_t size,
 		 struct small_alloc_info *info)
 {
-	(void)ptr;
 	struct small_mempool *small_mempool = small_mempool_search(alloc, size);
 	info->is_large = small_mempool == NULL;
-	if (info->is_large)
+	if (info->is_large) {
 		info->real_size = size;
-	else
-		info->real_size = small_mempool->used_pool->pool.objsize;
+	} else {
+		struct mslab *mslab = (struct mslab *)
+			slab_from_ptr(ptr, small_mempool->pool.slab_ptr_mask);
+		info->real_size = mslab->mempool->objsize;
+	}
 	assert(info->real_size >= size);
 }


### PR DESCRIPTION
Currently `real_size` is calculated as the size of a memory block that would be allocated for the requested number of bytes. However, this calculation is non-idempotent. For details see commit https://github.com/tarantool/small/commit/df7ba1f02f8839aec4166fef83d25f912debad9a ("small: implement new allocator strategy").

This patch switches `small_alloc_info()` to `slab_from_ptr()` that returns the actual slab that contains the requested `ptr`, so now `real_size` is always correct.

Needed for https://github.com/tarantool/tarantool/issues/10217

**Merge only together with https://github.com/tarantool/tarantool/pull/11652**