### PR TITLE
lsregion: fix mixing cached and large slabs in lsregion_to_iovec

### DIFF
--- a/include/small/lsregion.h
+++ b/include/small/lsregion.h
@@ -351,8 +351,13 @@ lsregion_gc(struct lsregion *lsregion, int64_t min_id)
 			lsregion->slabs.stats.total -= slab->slab_size;
 			slab_unmap(lsregion->arena, slab);
 		} else {
-			lslab_create(slab, slab->slab_size,
-				     ++lsregion->slab_id);
+			/*
+			 * We have to maintain an invariant that slab ids are
+			 * assigned in the same order as slabs are used, so this
+			 * slab's id will be assigned when it's taken from
+			 * cache.
+			 */
+			lslab_create(slab, slab->slab_size, LSLAB_NOT_USED_ID);
 			lsregion->cached = slab;
 		}
 	}

--- a/small/lsregion.c
+++ b/small/lsregion.c
@@ -75,6 +75,7 @@ lsregion_aligned_reserve_slow(struct lsregion *lsregion, size_t size,
 		/* If there is the cached slab then use it. */
 		slab = lsregion->cached;
 		lsregion->cached = NULL;
+		lslab_create(slab, slab->slab_size, ++lsregion->slab_id);
 		rlist_add_tail_entry(&lsregion->slabs.slabs, slab,
 				     next_in_list);
 	} else {


### PR DESCRIPTION
Cached slabs used to get their slab_id too early, at the moment of caching, and not at the moment of using the cache.

This didn't affect anything for normal-sized slabs, because for them the cache is always checked before trying to allocate another slab.

But in case a large slab was used, the invariant that slabs always receive a monotonically growing slab_id was broken. First, a normal slab was cached and received a slab_id = i. Then a large slab got allocated and received a slab_id = i + 1. Later a cached slab was taken with slab_id = i.

As a result mixing large and normal allocations could lead to a situation when lsregion_to_iovec couldn't flush a normal slab, because it considered it as already seen.

Let's fix this and always assign slab_ids at the moment the slabs are first used (either taken from cache or allocated).

Closes #109

**Corresponding Tarantool PR with a bump: https://github.com/tarantool/tarantool/pull/11647**