### PR TITLE
asan: zero used in `slab_cache_create`

### DIFF
--- a/small/slab_cache_asan.c
+++ b/small/slab_cache_asan.c
@@ -35,6 +35,7 @@ void
 slab_cache_create(struct slab_cache *cache, struct slab_arena *arena)
 {
 	quota_lessor_create(&cache->quota, arena->quota);
+	cache->used = 0;
 	cache->id = small_asan_reserve_id();
 	slab_cache_set_thread(cache);
 }

--- a/test/slab_cache.c
+++ b/test/slab_cache.c
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 #include "unit.h"
 
@@ -19,8 +20,12 @@ test_slab_cache(void)
 	plan(1);
 	header();
 
+	/* Trash the object to check that it's correctly initialized. */
+	memset(&cache, 0xff, sizeof(cache));
+
 	slab_arena_create(&arena, &quota, 0, 4000000, MAP_PRIVATE);
 	slab_cache_create(&cache, &arena);
+	fail_unless(slab_cache_used(&cache) == 0);
 
 	int i = 0;
 
@@ -50,6 +55,7 @@ test_slab_cache(void)
 	 */
 	ok_no_asan(cache.allocated.stats.total == arena.slab_size);
 
+	fail_unless(slab_cache_used(&cache) == 0);
 	slab_cache_destroy(&cache);
 	slab_arena_destroy(&arena);
 


### PR DESCRIPTION
Without it `slab_cache_used` won't work as expected if the slab cache is allocated dynamically.