### PR TITLE
perf: fix build on recent gcc

### DIFF
--- a/perf/small.cc
+++ b/perf/small.cc
@@ -260,9 +260,12 @@ finish:
 	small_alloc_test_finish();
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 static void
 generate_benchmark_args(benchmark::internal::Benchmark* b)
 {
+#pragma GCC diagnostic pop
 	for (unsigned size = SLAB_SIZE_MIN; size <= SLAB_SIZE_MAX; size *= 2) {
 		for (unsigned j = 0; j < objsize_arr.size(); j++) {
 			for (unsigned k = 0; k < alloc_factor_arr.size(); k++) {


### PR DESCRIPTION
Release build fails on recent gcc with error:

```
/home/shiny/dev/tarantool/src/lib/small/perf/small.cc:264:58: warning: ‘benchmark::internal::Benchmark’ is deprecated: Use ::benchmark::Benchmark instead [-Wdeprecated-declarations]
  264 | generate_benchmark_args(benchmark::internal::Benchmark* b)
      |                                                          ^
In file included from /home/shiny/dev/tarantool/src/lib/small/perf/small.cc:40:
/usr/include/benchmark/benchmark.h:1386:28: note: declared here
 1386 |     ::benchmark::Benchmark Benchmark;
      |                            ^~~~~~~~~
```

PR that tests small bump in Tarantool is https://github.com/tarantool/tarantool/pull/12679.